### PR TITLE
Fix syntax error in keccak-tiny/do.sh

### DIFF
--- a/keccak_tiny/do.sh
+++ b/keccak_tiny/do.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-cc=$(which clang-3.6||which gcc-4.9||which clang||||which gcc)
+cc=$(which clang-3.6||which gcc-4.9||which clang||which gcc)
 so=$(test -f /etc/asl.conf && printf dylib|| printf so)
 $cc "-Dinline=__attribute__((__always_inline__))" -O3 -march=native -std=c11 -Wextra -Wpedantic -Wall -dynamic -shared keccak-tiny.c -o libkeccak-tiny.$so
 $cc -Os -march=native -std=c11 -Wextra -Wpedantic -Wall -dynamic -shared keccak-tiny.c -o libkeccak-tiny-small.$so


### PR DESCRIPTION
When I try to run `do.sh`, I got this error:
command substitution: line 2: syntax error near unexpected token `||'
This commit fix this error.

By the way, thanks for this great library!


